### PR TITLE
Fix visible CSRF tokens in HTML forms

### DIFF
--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -13,7 +13,7 @@
             <li><a href="{{ url_for('view_past_posts') }}">View Past Posts</a></li>
             <li>
                 <form method="POST" action="{{ url_for('auth.logout') }}">
-                    {{ csrf_token() }}
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                     <button type="submit">Logout</button>
                 </form>
             </li>

--- a/UI/index.html
+++ b/UI/index.html
@@ -10,7 +10,7 @@
         <p>Hello, {{ current_user.username }}!</p>
         <p><a href="{{ url_for('dashboard') }}">Go to Dashboard</a></p>
         <form method="POST" action="{{ url_for('auth.logout') }}">
-            {{ csrf_token() }}
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             <button type="submit">Logout</button>
         </form>
     {% else %}

--- a/UI/login.html
+++ b/UI/login.html
@@ -119,8 +119,8 @@
       {% endif %}
     {% endwith %}
 
-    <form method="POST" action="{{ url_for('auth.login') }}">
-      {{ csrf_token() }}
+      <form method="POST" action="{{ url_for('auth.login') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
       <label for="username">Username</label>
       <input type="text" id="username" name="username" placeholder="Enter your username" required />

--- a/UI/register.html
+++ b/UI/register.html
@@ -16,7 +16,7 @@
       {% endif %}
     {% endwith %}
     <form method="POST" action="{{ url_for('auth.register') }}">
-        {{ csrf_token() }}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <label for="username">Username:</label>
         <input type="text" name="username" id="username" required autofocus />
         <br /><br />


### PR DESCRIPTION
## Summary
- hide CSRF token fields on login, registration, and logout forms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848932e6ab0832cbe1883068478322b