### PR TITLE
Enable POST method for logout

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -41,7 +41,7 @@ def login():
     return render_template('login.html')
 
 
-@auth.route('/logout')
+@auth.route('/logout', methods=['POST'])
 @login_required
 def logout():
     logout_user()


### PR DESCRIPTION
## Summary
- allow POST requests on `/auth/logout` route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68489fdc4c04832ca29531caef467b95