### PR TITLE
Implement post scheduling routes

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -1,9 +1,10 @@
 import os
-from flask import Flask, render_template, redirect, url_for
+from datetime import datetime
+from flask import Flask, render_template, redirect, url_for, request, flash
 from flask_wtf import CSRFProtect
 from flask_login import LoginManager, login_required, current_user
 from auth import auth
-from models import db, User
+from models import db, User, Post
 
 app = Flask(__name__, template_folder='UI')
 
@@ -41,6 +42,38 @@ def index():
 @login_required
 def dashboard():
     return render_template('dashboard.html', username=current_user.username)
+
+
+@app.route('/schedule', methods=['GET', 'POST'])
+@login_required
+def schedule_post():
+    if request.method == 'POST':
+        caption = request.form.get('caption')
+        image_url = request.form.get('image_url')
+        time_str = request.form.get('scheduled_time')
+        try:
+            scheduled_time = datetime.strptime(time_str, '%Y-%m-%dT%H:%M')
+        except (TypeError, ValueError):
+            flash('Invalid date/time format.')
+            return redirect(url_for('schedule_post'))
+
+        new_post = Post(user_id=current_user.id,
+                        caption=caption,
+                        image_url=image_url,
+                        scheduled_time=scheduled_time)
+        db.session.add(new_post)
+        db.session.commit()
+        flash('Post scheduled successfully!')
+        return redirect(url_for('dashboard'))
+
+    return render_template('schedule_post.html')
+
+
+@app.route('/posts')
+@login_required
+def view_past_posts():
+    posts = Post.query.filter_by(user_id=current_user.id).order_by(Post.scheduled_time.desc()).all()
+    return render_template('past_posts.html', posts=posts)
 
 
 # No need for /logout route here — handled by auth.logout

--- a/UI/past_posts.html
+++ b/UI/past_posts.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Past Posts</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        <h2>Your Posts</h2>
+        {% if posts %}
+            <ul>
+                {% for post in posts %}
+                <li>
+                    {% if post.image_url %}
+                        <img src="{{ post.image_url }}" alt="post image" style="max-width: 100%;" />
+                    {% endif %}
+                    <p>{{ post.caption }}</p>
+                    <small>{{ post.scheduled_time.strftime('%Y-%m-%d %H:%M') }}</small>
+                </li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p>No posts scheduled yet.</p>
+        {% endif %}
+        <div class="link"><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></div>
+    </div>
+</body>
+</html>

--- a/UI/schedule_post.html
+++ b/UI/schedule_post.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Schedule Post</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        <h2>Schedule a Post</h2>
+        <form method="POST" action="{{ url_for('schedule_post') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            <label for="image_url">Image URL</label>
+            <input type="text" id="image_url" name="image_url" required />
+            <label for="caption">Caption</label>
+            <input type="text" id="caption" name="caption" required />
+            <label for="scheduled_time">Scheduled Time</label>
+            <input type="datetime-local" id="scheduled_time" name="scheduled_time" required />
+            <button type="submit">Schedule</button>
+        </form>
+        <div class="link"><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></div>
+    </div>
+</body>
+</html>

--- a/models.py
+++ b/models.py
@@ -1,5 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import UserMixin
+from datetime import datetime
 
 db = SQLAlchemy()
 
@@ -17,3 +18,14 @@ class User(UserMixin, db.Model):
     def check_password(self, password):
         from werkzeug.security import check_password_hash
         return check_password_hash(self.password_hash, password)
+
+
+class Post(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    caption = db.Column(db.String(2200))
+    image_url = db.Column(db.String(500))
+    scheduled_time = db.Column(db.DateTime, default=datetime.utcnow)
+    posted = db.Column(db.Boolean, default=False)
+
+    user = db.relationship('User', backref='posts')


### PR DESCRIPTION
## Summary
- allow users to schedule posts and view their posts
- define `Post` model for storing scheduled posts
- create templates for scheduling posts and viewing post history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a0014534832ca317d9a013f17e76