### PR TITLE
Fix extraneous string shown on logout form

### DIFF
--- a/UI/index.html
+++ b/UI/index.html
@@ -76,7 +76,7 @@
             <p>Hello, {{ current_user.username }}!</p>
             <a href="{{ url_for('dashboard') }}">Go to Dashboard</a>
             <form method="POST" action="{{ url_for('auth.logout') }}">
-                {{ csrf_token() }}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
                 <button type="submit">Logout</button>
             </form>
         {% else %}


### PR DESCRIPTION
## Summary
- ensure the CSRF token on the homepage logout form is hidden

## Testing
- `python -m py_compile BD.py auth.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6848a250c97c832cbae6367be67bd6a1