### PR TITLE
Enforce SECRET_KEY requirement

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -8,7 +8,10 @@ from models import db, User, Post
 
 app = Flask(__name__, template_folder='UI')
 
-app.secret_key = os.getenv('SECRET_KEY') or 'supersecretkey'
+secret_key = os.getenv('SECRET_KEY')
+if not secret_key:
+    raise RuntimeError("SECRET_KEY environment variable not set")
+app.secret_key = secret_key
 
 # Database configuration
 app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL') or 'sqlite:///app.db'

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ A Flask-based social media scheduler web app that allows users to:
    ```bash
    pip install Flask Flask-WTF Flask-Login Flask-SQLAlchemy
    ```
-3. (Optional) set environment variables:
-   - `SECRET_KEY` – secret key for Flask sessions.
-   - `DATABASE_URL` – SQLAlchemy connection string. Defaults to SQLite `app.db`.
+3. Set environment variables:
+   - `SECRET_KEY` – **required** secret key for Flask sessions. The app exits if this is not provided.
+   - `DATABASE_URL` – (optional) SQLAlchemy connection string. Defaults to SQLite `app.db`.
 4. Run the development server:
    ```bash
    python BD.py


### PR DESCRIPTION
## Summary
- exit at startup if `SECRET_KEY` is missing
- document SECRET_KEY requirement in README

## Testing
- `python -m py_compile BD.py auth.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ad1e4d68832cb4196932f7e9521f