### PR TITLE
Enable multi-platform posts and show uploaded file name

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -85,7 +85,7 @@ def schedule_post():
         image_url = request.form.get('image_url')
         uploaded_file = request.files.get('image_file')
         time_str = request.form.get('scheduled_time')
-        platform = request.form.get('platform')
+        platforms = request.form.getlist('platforms')
         try:
             scheduled_time = datetime.strptime(time_str, '%Y-%m-%dT%H:%M')
         except (TypeError, ValueError):
@@ -104,19 +104,25 @@ def schedule_post():
                 flash('Unsupported file type.')
                 return redirect(url_for('schedule_post'))
 
-        if platform == 'instagram' and not current_user.instagram_access_token:
-            flash('Please connect your Instagram account first.')
-            return redirect(url_for('connect_accounts'))
-        if platform == 'tiktok' and not current_user.tiktok_access_token:
-            flash('Please connect your TikTok account first.')
-            return redirect(url_for('connect_accounts'))
+        if not platforms:
+            flash('Please select at least one platform.')
+            return redirect(url_for('schedule_post'))
 
-        new_post = Post(user_id=current_user.id,
-                        caption=caption,
-                        image_url=image_url,
-                        scheduled_time=scheduled_time,
-                        platform=platform)
-        db.session.add(new_post)
+        for platform in platforms:
+            if platform == 'instagram' and not current_user.instagram_access_token:
+                flash('Please connect your Instagram account first.')
+                return redirect(url_for('connect_accounts'))
+            if platform == 'tiktok' and not current_user.tiktok_access_token:
+                flash('Please connect your TikTok account first.')
+                return redirect(url_for('connect_accounts'))
+
+            new_post = Post(user_id=current_user.id,
+                            caption=caption,
+                            image_url=image_url,
+                            scheduled_time=scheduled_time,
+                            platform=platform)
+            db.session.add(new_post)
+
         db.session.commit()
         flash('Post scheduled successfully!')
         return redirect(url_for('dashboard'))

--- a/UI/schedule_post.html
+++ b/UI/schedule_post.html
@@ -16,13 +16,14 @@
                 <p>Drag & Drop Image Here or Click to Upload</p>
                 <input type="file" id="image_file" name="image_file" accept="image/*" style="display:none" />
             </div>
+            <div id="file-info"></div>
             <label for="caption">Caption</label>
             <input type="text" id="caption" name="caption" required />
-            <label for="platform">Platform</label>
-            <select id="platform" name="platform" required>
-                <option value="instagram">Instagram</option>
-                <option value="tiktok">TikTok</option>
-            </select>
+            <label>Platforms</label>
+            <div class="platform-options">
+                <label><input type="checkbox" name="platforms" value="instagram"> Instagram</label>
+                <label><input type="checkbox" name="platforms" value="tiktok"> TikTok</label>
+            </div>
             <label for="scheduled_time">Scheduled Time</label>
             <input type="datetime-local" id="scheduled_time" name="scheduled_time" required />
             <button type="submit">Schedule</button>
@@ -33,6 +34,15 @@
 <script>
     const dropArea = document.getElementById('drop-area');
     const fileInput = document.getElementById('image_file');
+    const fileInfo = document.getElementById('file-info');
+
+    function updateFileInfo(files) {
+        if (files && files.length > 0) {
+            fileInfo.textContent = files[0].name;
+        } else {
+            fileInfo.textContent = '';
+        }
+    }
 
     dropArea.addEventListener('click', () => fileInput.click());
     ['dragenter', 'dragover'].forEach(eventName => {
@@ -51,6 +61,8 @@
     });
     dropArea.addEventListener('drop', e => {
         fileInput.files = e.dataTransfer.files;
+        updateFileInfo(fileInput.files);
     });
+    fileInput.addEventListener('change', () => updateFileInfo(fileInput.files));
 </script>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -112,3 +112,19 @@ nav a:hover {
 #drop-area.highlight {
   border-color: #4a90e2;
 }
+
+#file-info {
+  text-align: center;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+.platform-options {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.platform-options label {
+  font-weight: normal;
+}


### PR DESCRIPTION
## Summary
- allow scheduling posts to multiple platforms at once
- display chosen file name in the scheduling form
- add basic styles for new elements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d517e768832c827447d62037da04