### PR TITLE
Add inline calendar scheduling

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -84,10 +84,11 @@ def schedule_post():
         caption = request.form.get('caption')
         image_url = request.form.get('image_url')
         uploaded_file = request.files.get('image_file')
+        date_str = request.form.get('scheduled_date')
         time_str = request.form.get('scheduled_time')
         platforms = request.form.getlist('platforms')
         try:
-            scheduled_time = datetime.strptime(time_str, '%Y-%m-%dT%H:%M')
+            scheduled_time = datetime.strptime(f"{date_str} {time_str}", '%Y-%m-%d %H:%M')
         except (TypeError, ValueError):
             flash('Invalid date/time format.')
             return redirect(url_for('schedule_post'))

--- a/UI/schedule_post.html
+++ b/UI/schedule_post.html
@@ -24,8 +24,11 @@
                 <label><input type="checkbox" name="platforms" value="instagram"> Instagram</label>
                 <label><input type="checkbox" name="platforms" value="tiktok"> TikTok</label>
             </div>
-            <label for="scheduled_time">Scheduled Time</label>
-            <input type="datetime-local" id="scheduled_time" name="scheduled_time" required />
+            <label for="scheduled_date">Scheduled Date &amp; Time</label>
+            <div class="datetime-inputs">
+                <input type="date" id="scheduled_date" name="scheduled_date" required />
+                <input type="time" id="scheduled_time" name="scheduled_time" required />
+            </div>
             <button type="submit">Schedule</button>
         </form>
         <div class="link"><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></div>
@@ -64,5 +67,11 @@
         updateFileInfo(fileInput.files);
     });
     fileInput.addEventListener('change', () => updateFileInfo(fileInput.files));
+
+    // Show the calendar immediately on page load if supported
+    const dateInput = document.getElementById('scheduled_date');
+    if (dateInput && dateInput.showPicker) {
+        dateInput.showPicker();
+    }
 </script>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -128,3 +128,9 @@ nav a:hover {
 .platform-options label {
   font-weight: normal;
 }
+
+.datetime-inputs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- split scheduled datetime field into separate date and time inputs
- adjust parsing of date and time in backend
- style datetime inputs and display calendar on load

## Testing
- `python -m py_compile BD.py models.py auth.py`
- `python BD.py` *(fails: Running server)*

------
https://chatgpt.com/codex/tasks/task_e_6848d7d41478832cb2bd0a8933b68e7a