### PR TITLE
Fix Instagram OAuth redirect

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -111,7 +111,7 @@ def instagram_callback():
     current_user.ig_user_id = token.get('user_id')
     db.session.commit()
     flash('Instagram connected!')
-    return redirect(url_for('dashboard'))
+    return redirect(url_for('connect_accounts'))
 
 
 @app.route('/oauth/tiktok')


### PR DESCRIPTION
## Summary
- update the Instagram OAuth callback to redirect the user back to the site after authorization

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848dc32138c832ca2df406eddee2508