### PR TITLE
Fix environment variable loading

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -7,9 +7,14 @@ from flask_login import LoginManager, login_required, current_user
 from authlib.integrations.flask_client import OAuth
 from auth import auth
 from models import db, User, Post
+from pathlib import Path
 from dotenv import load_dotenv
 
-load_dotenv(".env.example")  
+# Load variables from `.env` if present. If not, fall back to `.env.example` so
+# the sample app still runs with default values.
+load_dotenv()
+if not os.getenv("SECRET_KEY") and Path(".env.example").exists():
+    load_dotenv(".env.example")
 
 app = Flask(__name__, template_folder='UI')
 # Removed redundant load_dotenv() call to avoid conflicts

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A Flask-based social media scheduler web app that allows users to:
    ```bash
    cp .env.example .env
    ```
-   Set environment variables inside `.env`:
+   Set environment variables inside `.env` (the application loads this file automatically and will fall back to `.env.example` if needed):
    - `SECRET_KEY` – **required** secret key for Flask sessions. The app exits if this is not provided.
    - `DATABASE_URL` – (optional) SQLAlchemy connection string. Defaults to SQLite `app.db`.
 4. Run the development server:


### PR DESCRIPTION
## Summary
- load environment variables from `.env` by default
- mention fallback behavior in README

## Testing
- `python -m py_compile BD.py auth.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6848dd6fc488832cbe76f9353566e14c