### PR TITLE
Add email and password confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Flask-based social media scheduler web app that allows users to:
 
-✅ Register / Login
+✅ Register / Login with email and password confirmation
 ✅ Connect Instagram or TikTok accounts
 ✅ Schedule posts for either platform
 ✅ View past posts

--- a/UI/register.html
+++ b/UI/register.html
@@ -17,8 +17,17 @@
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             <label for="username">Username:</label>
             <input type="text" name="username" id="username" required autofocus />
+
+            <label for="email">Email:</label>
+            <input type="email" name="email" id="email" required />
+            <label for="confirm_email">Confirm Email:</label>
+            <input type="email" name="confirm_email" id="confirm_email" required />
+
             <label for="password">Password:</label>
             <input type="password" name="password" id="password" required />
+            <label for="confirm_password">Confirm Password:</label>
+            <input type="password" name="confirm_password" id="confirm_password" required />
+
             <button type="submit">Register</button>
         </form>
         <div class="link">Already have an account? <a href="{{ url_for('auth.login') }}">Login here</a></div>

--- a/auth.py
+++ b/auth.py
@@ -1,20 +1,53 @@
 from flask import Blueprint, render_template, redirect, url_for, request, flash
 from flask_login import login_user, logout_user, login_required, current_user
 from models import User, db
+import re
 
 auth = Blueprint('auth', __name__)
+
+
+def _is_strong_password(password: str) -> bool:
+    """Simple password strength checker."""
+    if len(password) < 8:
+        return False
+    if not re.search(r"[a-z]", password):
+        return False
+    if not re.search(r"[A-Z]", password):
+        return False
+    if not re.search(r"\d", password):
+        return False
+    return True
 
 @auth.route('/register', methods=['GET', 'POST'])
 def register():
     if request.method == 'POST':
         username = request.form.get('username')
+        email = request.form.get('email')
+        confirm_email = request.form.get('confirm_email')
         password = request.form.get('password')
+        confirm_password = request.form.get('confirm_password')
 
         if User.query.filter_by(username=username).first():
             flash('Username already exists.')
             return redirect(url_for('auth.register'))
 
-        new_user = User(username=username)
+        if User.query.filter_by(email=email).first():
+            flash('Email already registered.')
+            return redirect(url_for('auth.register'))
+
+        if email != confirm_email:
+            flash('Emails do not match.')
+            return redirect(url_for('auth.register'))
+
+        if password != confirm_password:
+            flash('Passwords do not match.')
+            return redirect(url_for('auth.register'))
+
+        if not _is_strong_password(password):
+            flash('Password must be at least 8 characters long and include a lower case letter, upper case letter and a number.')
+            return redirect(url_for('auth.register'))
+
+        new_user = User(username=username, email=email)
         new_user.set_password(password)
         db.session.add(new_user)
         db.session.commit()

--- a/models.py
+++ b/models.py
@@ -7,6 +7,7 @@ db = SQLAlchemy()
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(150), unique=True, nullable=False)
+    email = db.Column(db.String(150), unique=True, nullable=False)
     password_hash = db.Column(db.String(256), nullable=False)
     instagram_access_token = db.Column(db.String(500))
     ig_user_id = db.Column(db.String(100))


### PR DESCRIPTION
## Summary
- include email field in user model
- validate strong password and add confirm fields
- collect confirm email and password in registration page
- mention updated feature in README

## Testing
- `pytest -q`
- `python -m py_compile auth.py models.py BD.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ddc9afcc832cba88705b439584bd