### PR TITLE
Ensure email input uses same style as username

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -36,6 +36,7 @@ label {
 }
 input[type="text"],
 input[type="password"],
+input[type="email"],
 input[type="date"],
 input[type="time"],
 .flatpickr-input {
@@ -48,6 +49,7 @@ input[type="time"],
 }
 input[type="text"]:focus,
 input[type="password"]:focus,
+input[type="email"]:focus,
 input[type="date"]:focus,
 input[type="time"]:focus,
 .flatpickr-input:focus {


### PR DESCRIPTION
## Summary
- style email inputs consistently with other form fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e0d77f70832cbab30a439778f7b4