### PR TITLE
Fix CSRF issue for caption suggestions

### DIFF
--- a/UI/schedule_post.html
+++ b/UI/schedule_post.html
@@ -112,9 +112,13 @@
         }
         suggestionsEl.textContent = 'Generating...';
         try {
+            const csrfToken = document.querySelector('input[name="csrf_token"]').value;
             const response = await fetch('/suggest_captions', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken
+                },
                 body: JSON.stringify({ image: imgSrc })
             });
             const data = await response.json();


### PR DESCRIPTION
## Summary
- handle CSRF token for AJAX caption suggestion request

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: E501 line too long, F401, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848ea2d69c4832c90db89a474c1f24d