### PR TITLE
Fix past post list time duplication

### DIFF
--- a/UI/past_posts.html
+++ b/UI/past_posts.html
@@ -16,7 +16,11 @@
                         <img src="{{ post.image_url }}" alt="post image" style="max-width: 100%;" />
                     {% endif %}
                     <p>{{ post.caption }}</p>
-                    <small>{{ post.scheduled_time.strftime('%Y-%m-%d %H:%M') }} - {{ post.scheduled_time.strftime('%Y-%m-%d %H:%M') }}</small>
+                    <small>
+                        {{ post.scheduled_time.strftime('%Y-%m-%d %H:%M') }} -
+                        {{ post.platform.capitalize() }} -
+                        {% if post.posted %}Posted{% else %}Scheduled{% endif %}
+                    </small>
                 </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
## Summary
- tweak past posts display to show platform and posted status instead of duplicating the scheduled time

## Testing
- `python -m py_compile BD.py auth.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_684dba0a1cc4832caf06cf8f21c74bc7