### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Flask-SQLAlchemy
 python-dotenv
 Authlib
 openai
+requests


### PR DESCRIPTION
## Summary
- add custom retries and messaging for OpenAI API failures
- install requests library
- update tests to patch OpenAI client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbb16413c832c92c583c5ca21bd98