### PR TITLE
Fix OpenAI model name

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -157,7 +157,7 @@ def suggest_captions():
     for attempt in range(attempts):
         try:
             response = client.chat.completions.create(
-                model='gpt-4-vision-preview',
+                model='gpt-4o',
                 messages=[
                     {
                         'role': 'user',


### PR DESCRIPTION
## Summary
- update deprecated `gpt-4-vision-preview` to `gpt-4o`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcbbe3ef0832c9f9b056cb4cfdae8