### PR TITLE
Remove manual token entry for social accounts

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -86,23 +86,10 @@ def dashboard():
                            instagram_connected=instagram_connected,
                            tiktok_connected=tiktok_connected)
 
-@app.route('/connect', methods=['GET', 'POST'])
+@app.route('/connect')
 @login_required
 def connect_accounts():
-    if request.method == 'POST':
-        current_user.instagram_access_token = request.form.get('instagram_token')
-        current_user.ig_user_id = request.form.get('instagram_user_id')
-        current_user.tiktok_access_token = request.form.get('tiktok_token')
-        current_user.tiktok_user_id = request.form.get('tiktok_user_id')
-        db.session.commit()
-        flash('Accounts connected!')
-        return redirect(url_for('dashboard'))
-
-    return render_template('connect_accounts.html',
-                           instagram_token=current_user.instagram_access_token,
-                           instagram_user_id=current_user.ig_user_id,
-                           tiktok_token=current_user.tiktok_access_token,
-                           tiktok_user_id=current_user.tiktok_user_id)
+    return render_template('connect_accounts.html')
 
 @app.route('/oauth/instagram')
 @login_required

--- a/README.md
+++ b/README.md
@@ -59,28 +59,9 @@ database.
 
 The dashboard and authentication pages are under the `UI` folder.
 
-## Connecting social accounts without OAuth
+## Connecting social accounts
 
-If OAuth authentication fails or cannot be used, the app still allows you to
-link Instagram and TikTok accounts by manually entering access tokens. Navigate
-to **Connect Social Accounts** from the dashboard. The form lets you paste the
-access token and user ID for each platform:
-
-```
-<form method="POST" action="{{ url_for('connect_accounts') }}">
-    <label for="instagram_token">Instagram Access Token</label>
-    <input type="text" id="instagram_token" name="instagram_token" placeholder="Paste your Instagram token" />
-
-    <label for="instagram_user_id">Instagram User ID</label>
-    <input type="text" id="instagram_user_id" name="instagram_user_id" placeholder="Your Instagram user ID" />
-
-    <label for="tiktok_token">TikTok Access Token</label>
-    <input type="text" id="tiktok_token" name="tiktok_token" placeholder="Paste your TikTok token" />
-
-    <label for="tiktok_user_id">TikTok User ID</label>
-    <input type="text" id="tiktok_user_id" name="tiktok_user_id" placeholder="Your TikTok user ID" />
-```
-
-Select a platform from the drop-down to see tips on generating tokens from the
-respective developer portals. After saving, the tokens are stored in the
-database and your accounts will be treated as connected.
+Open the **Connect Social Accounts** page from the dashboard and use the
+provided buttons to authorize Instagram or TikTok via OAuth. After you approve
+access, the obtained tokens are stored automatically and the dashboard will show
+the platforms as connected.

--- a/UI/connect_accounts.html
+++ b/UI/connect_accounts.html
@@ -120,15 +120,7 @@
 <body>
     <div class="container">
         <h2>Connect Social Accounts</h2>
-        <p>Connect your accounts using OAuth below, or manually provide access tokens.</p>
-
-        <label for="platform_select">Choose a platform for instructions</label>
-        <select id="platform_select">
-            <option value="">-- Select a platform --</option>
-            <option value="instagram">Instagram</option>
-            <option value="tiktok">TikTok</option>
-        </select>
-        <p id="token-instructions" class="instructions"></p>
+        <p class="instructions">Use the buttons below to authorize Instagram and TikTok.</p>
 
         <div class="oauth-buttons">
             <a href="{{ url_for('oauth_instagram') }}" class="oauth-btn">Connect Instagram via OAuth</a>
@@ -143,38 +135,8 @@
           {% endif %}
         {% endwith %}
 
-        <form method="POST" action="{{ url_for('connect_accounts') }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-
-            <label for="instagram_token">Instagram Access Token</label>
-            <input type="text" id="instagram_token" name="instagram_token" value="{{ instagram_token or '' }}" placeholder="Paste your Instagram token" />
-
-            <label for="instagram_user_id">Instagram User ID</label>
-            <input type="text" id="instagram_user_id" name="instagram_user_id" value="{{ instagram_user_id or '' }}" placeholder="Your Instagram user ID" />
-
-            <label for="tiktok_token">TikTok Access Token</label>
-            <input type="text" id="tiktok_token" name="tiktok_token" value="{{ tiktok_token or '' }}" placeholder="Paste your TikTok token" />
-
-            <label for="tiktok_user_id">TikTok User ID</label>
-            <input type="text" id="tiktok_user_id" name="tiktok_user_id" value="{{ tiktok_user_id or '' }}" placeholder="Your TikTok user ID" />
-
-            <button type="submit">Save</button>
-        </form>
-
         <div class="link"><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></div>
     </div>
-<script>
-    const select = document.getElementById('platform_select');
-    const instructions = document.getElementById('token-instructions');
-    select.addEventListener('change', () => {
-        if (select.value === 'instagram') {
-            instructions.textContent = 'Generate an Instagram access token from the Facebook Developer portal under Instagram Basic Display.';
-        } else if (select.value === 'tiktok') {
-            instructions.textContent = 'Get a TikTok access token on developers.tiktok.com by creating an app and visiting the Authentication section.';
-        } else {
-            instructions.textContent = '';
-        }
-    });
-</script>
+<script></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove manual access token inputs from connect_accounts.html
- simplify connect_accounts route to display OAuth options only
- update README instructions for connecting accounts via OAuth

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507a865e68832c9608342703d6d787