### PR TITLE
Add video upload utilities

### DIFF
--- a/BD.py
+++ b/BD.py
@@ -6,6 +6,7 @@ from flask_wtf import CSRFProtect
 from flask_login import LoginManager, login_required, current_user
 from authlib.integrations.flask_client import OAuth
 import openai
+from moviepy.video.io.VideoFileClip import VideoFileClip
 from openai import RateLimitError, APIError, APIConnectionError, APITimeoutError
 import time
 from auth import auth
@@ -23,6 +24,7 @@ app = Flask(__name__, template_folder='UI')
 # Removed redundant load_dotenv() call to avoid conflicts
 app.config['UPLOAD_FOLDER'] = os.path.join('static', 'uploads')
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
+ALLOWED_VIDEO_EXTENSIONS = {'mp4', 'mov', 'avi', 'mkv'}
 
 oauth = OAuth(app)
 oauth.register(
@@ -239,6 +241,42 @@ def schedule_post():
 def view_past_posts():
     posts = Post.query.filter_by(user_id=current_user.id).order_by(Post.scheduled_time.desc()).all()
     return render_template('past_posts.html', posts=posts)
+
+
+@app.route('/video_tools', methods=['GET', 'POST'])
+@login_required
+def video_tools():
+    short_video_url = None
+    thumbnail_url = None
+    if request.method == 'POST':
+        video_file = request.files.get('video_file')
+        if video_file and video_file.filename:
+            ext = video_file.filename.rsplit('.', 1)[-1].lower()
+            if ext in ALLOWED_VIDEO_EXTENSIONS:
+                filename = f"{datetime.now().strftime('%Y%m%d%H%M%S')}_{secure_filename(video_file.filename)}"
+                os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+                file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+                video_file.save(file_path)
+                clip = VideoFileClip(file_path)
+                duration = clip.duration
+                short_clip = clip.subclipped(0, min(20, duration))
+                short_name = f"short_{filename}"
+                short_path = os.path.join(app.config['UPLOAD_FOLDER'], short_name)
+                short_clip.write_videofile(short_path, codec='libx264', audio_codec='aac', logger=None)
+                thumb_name = f"thumb_{os.path.splitext(filename)[0]}.jpg"
+                thumb_path = os.path.join(app.config['UPLOAD_FOLDER'], thumb_name)
+                clip.save_frame(thumb_path, t=min(1, duration))
+                clip.close()
+                short_clip.close()
+                short_video_url = url_for('static', filename=f'uploads/{short_name}')
+                thumbnail_url = url_for('static', filename=f'uploads/{thumb_name}')
+            else:
+                flash('Unsupported video type.')
+                return redirect(url_for('video_tools'))
+        else:
+            flash('No video uploaded.')
+            return redirect(url_for('video_tools'))
+    return render_template('video_tools.html', short_video_url=short_video_url, thumbnail_url=thumbnail_url)
 
 
 with app.app_context():

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Flask-based social media scheduler web app that allows users to:
 ✅ Connect Instagram or TikTok accounts
 ✅ Schedule posts for either platform
 ✅ View past posts
+✅ Upload videos to generate a thumbnail and 20-second preview
 ✅ Secure CSRF-protected login/logout flow
 ✅ Background scheduler for automated posting
 

--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -25,6 +25,7 @@
             <ul>
                 <li><a href="{{ url_for('schedule_post') }}">Schedule Post</a></li>
                 <li><a href="{{ url_for('view_past_posts') }}">View Past Posts</a></li>
+                <li><a href="{{ url_for('video_tools') }}">Video Tools</a></li>
                 <li><a href="{{ url_for('connect_accounts') }}">Connect Social Accounts</a></li>
                 <li>
                     <form method="POST" action="{{ url_for('auth.logout') }}">

--- a/UI/video_tools.html
+++ b/UI/video_tools.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Video Tools</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="container">
+    <h2>Upload a Video</h2>
+    <form method="POST" enctype="multipart/form-data">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="file" name="video_file" accept="video/*" required />
+        <button type="submit">Upload</button>
+    </form>
+    {% if thumbnail_url %}
+    <h3>Thumbnail</h3>
+    <img src="{{ thumbnail_url }}" alt="Thumbnail" style="max-width: 100%;" />
+    {% endif %}
+    {% if short_video_url %}
+    <h3>20-second Clip</h3>
+    <video src="{{ short_video_url }}" controls style="max-width: 100%;"></video>
+    {% endif %}
+    <div class="link"><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></div>
+</div>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ python-dotenv
 Authlib
 openai
 requests
+moviepy
+httpx

--- a/tests/test_video_tools.py
+++ b/tests/test_video_tools.py
@@ -1,0 +1,41 @@
+import os
+import tempfile
+from moviepy.video.VideoClip import ColorClip
+import pytest
+
+# Set required environment variables before importing the app
+os.environ.setdefault('SECRET_KEY', 'test-secret')
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+
+import BD
+
+@pytest.fixture
+def client():
+    BD.app.config['TESTING'] = True
+    BD.app.config['LOGIN_DISABLED'] = True
+    BD.app.config['WTF_CSRF_ENABLED'] = False
+    with BD.app.test_client() as client:
+        yield client
+
+def _create_sample_video(path):
+    clip = ColorClip(size=(64, 64), color=(255, 0, 0), duration=1)
+    clip.write_videofile(path, fps=24, codec='libx264', audio=False, logger=None)
+    clip.close()
+
+
+def test_video_tools_get(client):
+    resp = client.get('/video_tools')
+    assert resp.status_code == 200
+
+
+def test_video_processing(client, tmp_path):
+    video_path = tmp_path / 'vid.mp4'
+    _create_sample_video(str(video_path))
+    with open(video_path, 'rb') as f:
+        data = {'video_file': (f, 'vid.mp4')}
+        resp = client.post('/video_tools', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    assert b'20-second Clip' in resp.data
+    files = os.listdir(os.path.join('static', 'uploads'))
+    assert any(name.startswith('short_') for name in files)
+    assert any(name.startswith('thumb_') for name in files)


### PR DESCRIPTION
## Summary
- allow uploading videos and processing to a short clip
- create a thumbnail with `moviepy`
- add a Video Tools page and dashboard link
- document video processing feature
- test video processing route

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850aced43f8832c89d15d95fe827ad6