### PR TITLE
Add analytics page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Flask-based social media scheduler web app that allows users to:
 ✅ Connect Instagram, TikTok or YouTube accounts
 ✅ Schedule posts for any platform
 ✅ View past posts
+✅ Track post analytics and follower growth
 ✅ Upload videos to generate a thumbnail and 20-second preview
 ✅ Secure CSRF-protected login/logout flow
 ✅ Background scheduler for automated posting
@@ -69,3 +70,9 @@ Open the **Connect Social Accounts** page from the dashboard and use the
 provided buttons to authorize Instagram, TikTok or YouTube via OAuth. After you
 approve access, the obtained tokens are stored automatically and the dashboard
 will show the platforms as connected.
+
+## Analytics
+
+Use the **Analytics** tab on the dashboard to view engagement for your posts and
+track follower counts over time. Choose the desired platform from the dropdown
+menu to filter results.

--- a/UI/analytics.html
+++ b/UI/analytics.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Analytics</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="container">
+    <h2>Analytics - {{ platform.capitalize() }}</h2>
+    <form method="get" action="{{ url_for('analytics') }}">
+        <label for="platform">Platform</label>
+        <select name="platform" id="platform" onchange="this.form.submit()">
+            <option value="instagram" {% if platform == 'instagram' %}selected{% endif %}>Instagram</option>
+            <option value="tiktok" {% if platform == 'tiktok' %}selected{% endif %}>TikTok</option>
+            <option value="youtube" {% if platform == 'youtube' %}selected{% endif %}>YouTube</option>
+        </select>
+    </form>
+
+    <h3>Follower Growth</h3>
+    {% if follower_data %}
+        <ul>
+        {% for f in follower_data %}
+            <li>{{ f.timestamp.strftime('%Y-%m-%d') }}: {{ f.followers }}</li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        <p>No follower data.</p>
+    {% endif %}
+
+    <h3>Posts</h3>
+    {% if posts %}
+        <ul>
+        {% for post in posts %}
+            <li>
+                {{ post.caption }} - Likes: {{ post.likes }} Comments: {{ post.comments }} Shares: {{ post.shares }} Saves: {{ post.saves }}
+            </li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        <p>No posts for this platform.</p>
+    {% endif %}
+
+    <h3>Top Posts</h3>
+    {% if top_posts %}
+        <ol>
+        {% for post in top_posts %}
+            <li>{{ post.caption }} ({{ (post.likes + post.comments + post.shares + post.saves) }})</li>
+        {% endfor %}
+        </ol>
+    {% else %}
+        <p>No top posts.</p>
+    {% endif %}
+
+    <div class="link"><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></div>
+</div>
+</body>
+</html>

--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -11,6 +11,7 @@
             <li><a href="{{ url_for('schedule_post') }}">Schedule Post</a></li>
             <li><a href="{{ url_for('view_past_posts') }}">View Past Posts</a></li>
             <li><a href="{{ url_for('video_tools') }}">Video Tools</a></li>
+            <li><a href="{{ url_for('analytics') }}">Analytics</a></li>
             <li><a href="{{ url_for('connect_accounts') }}">Connect Social Accounts</a></li>
             <li>
                 <form method="POST" action="{{ url_for('auth.logout') }}">

--- a/models.py
+++ b/models.py
@@ -34,5 +34,19 @@ class Post(db.Model):
     scheduled_time = db.Column(db.DateTime, default=datetime.utcnow)
     posted = db.Column(db.Boolean, default=False)
     platform = db.Column(db.String(50), default='instagram', nullable=False)
+    likes = db.Column(db.Integer, default=0)
+    comments = db.Column(db.Integer, default=0)
+    shares = db.Column(db.Integer, default=0)
+    saves = db.Column(db.Integer, default=0)
 
     user = db.relationship('User', backref='posts')
+
+
+class FollowerTrend(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    platform = db.Column(db.String(50), nullable=False)
+    followers = db.Column(db.Integer, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship('User', backref='follower_trends')

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,41 @@
+import os
+from datetime import datetime
+import pytest
+import sys
+import os as _os
+sys.path.insert(0, _os.path.abspath(_os.path.join(_os.path.dirname(__file__), '..')))
+
+os.environ.setdefault('SECRET_KEY', 'test-secret')
+os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+
+import BD
+
+@pytest.fixture
+def client():
+    BD.app.config['TESTING'] = True
+    BD.app.config['WTF_CSRF_ENABLED'] = False
+    with BD.app.app_context():
+        BD.db.drop_all()
+        BD.db.create_all()
+        user = BD.User(username='u', email='u@example.com')
+        user.set_password('pw')
+        BD.db.session.add(user)
+        BD.db.session.commit()
+        user_id = user.id
+        post = BD.Post(user_id=user_id, caption='post1', platform='instagram', likes=10, comments=5, shares=1, saves=2)
+        BD.db.session.add(post)
+        trend1 = BD.FollowerTrend(user_id=user.id, platform='instagram', followers=100, timestamp=datetime(2024,1,1))
+        trend2 = BD.FollowerTrend(user_id=user.id, platform='instagram', followers=120, timestamp=datetime(2024,1,2))
+        BD.db.session.add_all([trend1, trend2])
+        BD.db.session.commit()
+    with BD.app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['_user_id'] = str(user_id)
+        yield client
+
+def test_analytics_page(client):
+    resp = client.get('/analytics?platform=instagram')
+    assert resp.status_code == 200
+    data = resp.get_data(as_text=True)
+    assert 'post1' in data
+    assert '120' in data

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -4,6 +4,9 @@ from unittest.mock import patch, Mock
 import httpx
 import openai
 import pytest
+import sys
+import os as _os
+sys.path.insert(0, _os.path.abspath(_os.path.join(_os.path.dirname(__file__), '..')))
 
 # Set required environment variables before importing the app
 os.environ.setdefault('SECRET_KEY', 'test-secret')

--- a/tests/test_video_tools.py
+++ b/tests/test_video_tools.py
@@ -2,6 +2,9 @@ import os
 import tempfile
 from moviepy.video.VideoClip import ColorClip
 import pytest
+import sys
+import os as _os
+sys.path.insert(0, _os.path.abspath(_os.path.join(_os.path.dirname(__file__), '..')))
 
 # Set required environment variables before importing the app
 os.environ.setdefault('SECRET_KEY', 'test-secret')


### PR DESCRIPTION
## Summary
- track engagement metrics in `models` and add follower trend table
- show analytics from `/analytics` route
- link to new analytics page from dashboard
- update README with analytics info
- add tests for analytics and update existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b79aac68832c89b1dc327a5d5679