### PR TITLE
Use timezone-aware timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ For production setups you would normally use a migration tool such as
 [Flask-Migrate](https://flask-migrate.readthedocs.io/) instead of deleting the
 database.
 
+All timestamps stored in the database are saved in **UTC** for consistency
+across deployments.
+
 The dashboard and authentication pages are under the `UI` folder.
 
 ## Connecting social accounts

--- a/models.py
+++ b/models.py
@@ -1,6 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import UserMixin
-from datetime import datetime
+from datetime import datetime, UTC
 
 db = SQLAlchemy()
 
@@ -31,7 +31,10 @@ class Post(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     caption = db.Column(db.String(2200))
     image_url = db.Column(db.String(500))
-    scheduled_time = db.Column(db.DateTime, default=datetime.utcnow)
+    scheduled_time = db.Column(
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(UTC)
+    )
     posted = db.Column(db.Boolean, default=False)
     platform = db.Column(db.String(50), default='instagram', nullable=False)
     likes = db.Column(db.Integer, default=0)
@@ -47,6 +50,9 @@ class FollowerTrend(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     platform = db.Column(db.String(50), nullable=False)
     followers = db.Column(db.Integer, nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    timestamp = db.Column(
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(UTC)
+    )
 
     user = db.relationship('User', backref='follower_trends')

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, UTC
 import pytest
 import sys
 import os as _os
@@ -24,8 +24,10 @@ def client():
         user_id = user.id
         post = BD.Post(user_id=user_id, caption='post1', platform='instagram', likes=10, comments=5, shares=1, saves=2)
         BD.db.session.add(post)
-        trend1 = BD.FollowerTrend(user_id=user.id, platform='instagram', followers=100, timestamp=datetime(2024,1,1))
-        trend2 = BD.FollowerTrend(user_id=user.id, platform='instagram', followers=120, timestamp=datetime(2024,1,2))
+        trend1 = BD.FollowerTrend(user_id=user.id, platform='instagram', followers=100,
+                                  timestamp=datetime(2024, 1, 1, tzinfo=UTC))
+        trend2 = BD.FollowerTrend(user_id=user.id, platform='instagram', followers=120,
+                                  timestamp=datetime(2024, 1, 2, tzinfo=UTC))
         BD.db.session.add_all([trend1, trend2])
         BD.db.session.commit()
     with BD.app.test_client() as client:


### PR DESCRIPTION
## Summary
- store Post and FollowerTrend timestamps in UTC
- update analytics test for timezone awareness
- document UTC usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4ddb0898832cbb2afc3fb5a0b813