### PR TITLE
Allow custom video clip selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Flask-based social media scheduler web app that allows users to:
 ✅ Schedule posts for any platform
 ✅ View past posts
 ✅ Track post analytics and follower growth
-✅ Upload videos to generate a thumbnail and 20-second preview
+✅ Upload videos to generate a thumbnail and custom preview clip (10/20/30 seconds)
 ✅ Secure CSRF-protected login/logout flow
 ✅ Background scheduler for automated posting
 

--- a/UI/video_tools.html
+++ b/UI/video_tools.html
@@ -12,6 +12,22 @@
     <form method="POST" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="file" name="video_file" accept="video/*" required />
+        <label>
+            Thumbnail time (s):
+            <input type="number" name="thumbnail_time" value="1" min="0" step="0.1" />
+        </label>
+        <label>
+            Clip start (s):
+            <input type="number" name="clip_start" value="0" min="0" step="0.1" />
+        </label>
+        <label>
+            Clip length:
+            <select name="clip_length">
+                <option value="10">10 seconds</option>
+                <option value="20" selected>20 seconds</option>
+                <option value="30">30 seconds</option>
+            </select>
+        </label>
         <button type="submit">Upload</button>
     </form>
     {% if thumbnail_url %}
@@ -19,7 +35,7 @@
     <img src="{{ thumbnail_url }}" alt="Thumbnail" style="max-width: 100%;" />
     {% endif %}
     {% if short_video_url %}
-    <h3>20-second Clip</h3>
+    <h3>{{ clip_length }}-second Clip</h3>
     <video src="{{ short_video_url }}" controls style="max-width: 100%;"></video>
     {% endif %}
     <div class="link"><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></div>

--- a/tests/test_video_tools.py
+++ b/tests/test_video_tools.py
@@ -21,7 +21,7 @@ def client():
         yield client
 
 def _create_sample_video(path):
-    clip = ColorClip(size=(64, 64), color=(255, 0, 0), duration=1)
+    clip = ColorClip(size=(64, 64), color=(255, 0, 0), duration=2)
     clip.write_videofile(path, fps=24, codec='libx264', audio=False, logger=None)
     clip.close()
 
@@ -35,10 +35,15 @@ def test_video_processing(client, tmp_path):
     video_path = tmp_path / 'vid.mp4'
     _create_sample_video(str(video_path))
     with open(video_path, 'rb') as f:
-        data = {'video_file': (f, 'vid.mp4')}
+        data = {
+            'video_file': (f, 'vid.mp4'),
+            'clip_start': '0',
+            'clip_length': '10',
+            'thumbnail_time': '0'
+        }
         resp = client.post('/video_tools', data=data, content_type='multipart/form-data')
     assert resp.status_code == 200
-    assert b'20-second Clip' in resp.data
+    assert b'10-second Clip' in resp.data
     files = os.listdir(os.path.join('static', 'uploads'))
     assert any(name.startswith('short_') for name in files)
     assert any(name.startswith('thumb_') for name in files)


### PR DESCRIPTION
## Summary
- enable user-defined start time and duration for video clips in `video_tools`
- let users pick the timestamp for thumbnails
- update video tools page UI for new fields
- adjust README bullet
- update tests for custom clip

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4e4755b4832c9fcf4d1e99abc7c9